### PR TITLE
Added BFD support. Updated code for newer SDEs (tested with 9.8.0-9.12.0). Does not compile with SDE 9.5.0 (and older) anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In `example_setup/README.md`, an explanation can be found to run the P4 implemen
 
 Currently the following features are not yet provided:
 - Peering connections
-- BFD support to detect link failures between border routers
+- SCMP support to communicate failures between border routers
 - Mixing of IPv4 and IPv6
 - Support to process EPIC and COLIBRI paths 
 
@@ -48,6 +48,7 @@ Currently the following features are not yet provided:
 
 - Joeri de Ruiter, SIDN Labs
 - Caspar Schutijser, SIDN Labs
+- Robin Wehner, NetSys Lab OvGU Magdeburg
 
 ## License
 

--- a/controller/bfd_handling.py
+++ b/controller/bfd_handling.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2023, NetSys Lab, Otto-von-Guericke-University Magdeburg
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from scapy.all import sniff, bind_layers, Ether, IP, UDP, sendp
+from scapy.contrib.bfd import BFD
+from scion_scapy.scion import SCION, SCIONOneHopPath, InfoField, HopField
+from scion_crypto import get_key, compute_mac
+from multiprocessing import Process, Lock, Pool, Value
+from tofino import *
+
+import argparse
+import time
+import random
+import binascii
+import ipaddress
+import json
+import socket
+import logging
+
+# Definitions:
+BFD_ADMIN_DOWN = 0
+BFD_DOWN = 1
+BFD_INIT = 2
+BFD_UP = 3
+
+logger = logging.getLogger('scion_onehope_processor')
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.INFO)
+
+# Class for a single BFD session
+class BfdSession:
+    def __init__(self, key, interface, srcMac, dstMac, srcIp, dstIp, additionalIfs, srcUdpPort, dstUdpPort,
+            srcIsd, dstIsd, srcAs, dstAs, myDiscrimi, egIfId):
+        # Set BFD packet fields
+        self.key = key
+        self.interface = interface
+        self.state = Value('i', BFD_DOWN)
+        self.stateMutex = Lock()
+        self.srcMAC = srcMac
+        self.dstMAC = dstMac
+        self.srcIP = srcIp
+        self.dstIP = dstIp
+        self.additionalIFs = additionalIfs
+        self.srcUDPPort = srcUdpPort
+        self.dstUDPPort = dstUdpPort
+        self.srcISD = srcIsd
+        self.dstISD = dstIsd
+        self.srcAS = srcAs
+        self.dstAS = dstAs
+        self.egressInterface = egIfId
+        self.myDiscrimi = myDiscrimi
+        self.yourDiscrimi = Value('i', 0)
+        # Initial value fro minimum Tx interval is 1 second, it is negotiated during the BFD session.
+        self.minTx = Value('i', 1000000)
+        self.downInterval = 1000000
+        # Normally required Rx interval is set to 200000 in SCION. Can be changed to decrease the BFD interval.
+        self.reqRx = 1000000
+        self.timeMutex = Lock()
+        self.timeout = Value('d', time.time() + 3)
+
+    # Send a BFD packet out
+    def sendPacket(self):
+        # Create SCION BFD packet with scapy
+        pkt = None
+        with self.timeMutex:
+            with self.stateMutex:
+                yourDiscriminator = self.yourDiscrimi.value
+                if self.state.value <= BFD_DOWN:
+                    yourDiscriminator = 0
+                pkt = Ether(src=self.srcMAC, dst=self.dstMAC)/ \
+                      IP(src=self.srcIP, dst=self.dstIP, ttl=64)/ \
+                      UDP(sport=self.srcUDPPort, dport=self.dstUDPPort)/ \
+                      SCION(qos=0xb8, flowID=0x0dead, nextHdr=0xCB, payloadLen=24,
+                            dstISD=self.dstISD, dstAS=self.dstAS,
+                            srcISD=self.srcISD, srcAS=self.srcAS,
+                            dstAddress=socket.inet_aton(self.dstIP), srcAddress=socket.inet_aton(self.srcIP))/ \
+                      BFD(sta=self.state.value,
+                          my_discriminator=self.myDiscrimi, your_discriminator=yourDiscriminator,
+                          min_tx_interval=self.minTx.value, min_rx_interval=self.reqRx, echo_rx_interval=0)
+            if self.dstAS == self.srcAS:
+                # Internal session - SCION Empty Path
+                pkt[SCION].hdrLen = 9
+                pkt[SCION].pathType = 0
+                pkt[SCION].path = ""
+            else:
+                # External session - SCION OneHop Path
+                pkt[SCION].hdrLen = 17
+                pkt[SCION].pathType = 2
+                pkt[SCION].path = SCIONOneHopPath()
+                pkt[SCION].path.infofield = InfoField()
+                pkt[SCION].path.hopfield0 = HopField()
+                pkt[SCION].path.hopfield1 = HopField()
+                
+                pkt[SCION].path.infofield.flags = 1
+                timestamp = int(time.time())
+                pkt[SCION].path.infofield.timestamp = timestamp
+                pkt[SCION].path.hopfield0.expTime = 63
+                pkt[SCION].path.hopfield0.consEgress = self.egressInterface
+                cmac = compute_mac(self.key, 0, timestamp, 63, 0, 0)
+                pkt[SCION].path.hopfield0.mac = int.from_bytes(cmac.digest()[0:6], byteorder='big')
+            # Send packet
+            sendp(pkt, iface=self.interface, verbose=0)
+    
+    # Reset the timeout for incoming packets
+    def setLastRxTime(self, timeout):
+        self.timeout.value = time.time() + timeout
+
+    # Getter for the actual state of the BFD session
+    def getState(self):
+        return self.state.value
+
+    # Setter for the actual state of the BFD session
+    def setState(self, state=int):
+        with self.stateMutex:
+            # Check, whether the received state is valid
+            if state >= BFD_ADMIN_DOWN and state <= BFD_UP:
+                self.state.value = state
+                return self.state.value
+        return -1
+
+    # Getter for the "yourDiscriminator" value
+    def getYourDiscrimi(self):
+        return self.yourDiscrimi.value
+
+    # Setter for the "yourDiscriminator" value
+    def setYourDiscrimi(self, yourDiscrimi):
+        # Check, that the parameter is non-zero and unknown
+        if self.yourDiscrimi.value != yourDiscrimi and yourDiscrimi != 0:
+            self.yourDiscrimi.value = yourDiscrimi
+            return 1
+        if self.yourDiscrimi.value == yourDiscrimi:
+            return 0
+        return -1
+
+    # Getter for actual used minimum Tx interval
+    def getTxInterval(self):
+        return self.minTx.value
+
+    # Setter for actual used minimum Tx interval
+    def setTxInterval(self, yourMinRx):
+        with self.timeMutex:
+            # Check, if the Session is able to handle messages in this interval or not
+            if yourMinRx < self.reqRx:
+                # If the interval is too fast, use the required Rx interval instead...
+                self.minTx.value = self.reqRx
+                return 0
+            else:
+                # ...otherwise use the newly received value
+                self.minTx.value = yourMinRx
+                return 1
+
+    # Down state (and Admin-Down as well) of the session
+    def down(self):
+        i = 0
+        while self.state.value == BFD_DOWN or self.state.value == BFD_ADMIN_DOWN:
+            # Measure the time needed for the function
+            startTime = time.time()
+            
+            # Send a packet every fifth time the function is called
+            if i == 0:
+                self.sendPacket()
+            i = (i + 1) % 5
+            
+            # Sleep for 1/5 of the BFD interval in down state minus jitter. This is done to react faster on state changes.
+            with self.timeMutex:
+                sleepTime = self.downInterval / 5 - (self.downInterval / 5 * 0.25 * random.random())
+            time.sleep(max(sleepTime / 1000000 - (time.time() - startTime), 0))
+
+    # Up state (and Init as well) of the session
+    def up(self):
+        initcnt = 0
+        while self.state.value == BFD_UP or self.state.value == BFD_INIT:
+            # Measure the time needed for the function
+            startTime = time.time()
+            
+            # If 10 BFD init frames were sent without the peer staying in state down,
+            # set session to state down to reset the session
+            with self.stateMutex:
+                if self.state.value == BFD_INIT:
+                    if initcnt > 9:
+                        self.state.value = BFD_DOWN
+                        with self.timeMutex:
+                            self.minTx.value = 1000000
+                    initcnt = initcnt + 1
+            
+            # If the peer does not send a BFD packet before the timeout is reached, set session to down
+            if time.time() > self.timeout.value:
+                with self.stateMutex:
+                    self.state.value = BFD_DOWN
+                with self.timeMutex:
+                    self.minTx.value = 1000000
+                return
+            
+            # Send a BFD packet
+            self.sendPacket()
+            
+            # Sleep for the negotiated amount of time minus jitter (and minus the time needed for this function)
+            with self.timeMutex:
+                sleepTime = self.minTx.value - (self.minTx.value * 0.25 * random.random())
+            time.sleep(max(sleepTime / 1000000 - (time.time() - startTime), 0))
+
+    # Run this session
+    def run(self):
+        while True:
+            # Apply either the down session or the up session algorithm
+            if self.state.value == BFD_DOWN or self.state.value == BFD_ADMIN_DOWN:
+                self.down()
+            if self.state.value == BFD_UP or self.state.value == BFD_INIT:
+                self.up()
+
+# The BFD handler registers all BFD sessions needed for the border router
+class BfdHandler:
+    def __init__(self, configFile, key, interface):
+        self.interface = interface
+        # Read config from file
+        configJSON = open(configFile)
+        config = json.load(configJSON)
+        configJSON.close()
+        # Read fields from config
+        self.hostAS = int('0x' + config['localAS'], 16)
+        self.hostISD = config['localISD']
+        self.egressInterfaces = []
+        self.egressPorts = []
+        self.dstIPs = []
+        additionalInterfaces = []
+        dstMACs = []
+        self.dstUDPPorts = []
+        dstISDs = []
+        dstASes = []
+        srcIPs = {}
+        srcMACs = {}
+        srcUDPPorts = {}
+        self.bfdSessions = []
+        self.bfdProcesses = []
+        for element in config['remoteDestinations']:
+            self.egressInterfaces.append(element['egressInterface'])
+            self.egressPorts.append(element['egressPortId'])
+            self.dstIPs.append(element['dstIP'])
+            additionalInterfaces.append([])
+            dstMACs.append(element['dstMAC'])
+            self.dstUDPPorts.append(element['dstPort'])
+            dstISDs.append(element['dstISD'])
+            dstASes.append(int('0x' + element['dstAS'], 16))
+        for element in config['localDestinations']:
+            self.egressInterfaces.append(element['egressInterface'])
+            self.egressPorts.append(element['egressPortId'])
+            self.dstIPs.append(element['dstIP'])
+            additionalInterfaces.append([])
+            for entry in config['localInterfaces']:
+                if element['dstIP'] == entry['dstIP']:
+                    additionalInterfaces[-1].append(entry['egressInterface'])
+            dstMACs.append(element['dstMAC'])
+            self.dstUDPPorts.append(element['dstPort'])
+            dstISDs.append(self.hostISD)
+            dstASes.append(self.hostAS)
+        for element in config['localSource']:
+            srcIPs[element['egressPortId']] = element['srcIP']
+            srcMACs[element['egressPortId']] = element['srcMAC']
+            srcUDPPorts[element['egressPortId']] = element['srcPort']
+        # Create BFD Sessions for each connected SCION reouter
+        for i in range(len(self.egressInterfaces)):
+            self.bfdSessions.append(BfdSession(key, self.interface, srcMACs[self.egressPorts[i]], dstMACs[i],
+                                    srcIPs[self.egressPorts[i]], self.dstIPs[i], additionalInterfaces[i],
+                                    srcUDPPorts[self.egressPorts[i]], self.dstUDPPorts[i],
+                                    self.hostISD, dstISDs[i], self.hostAS, dstASes[i],
+                                    random.randint(1, (2**32) - 1), self.egressInterfaces[i]))
+            logger.info("Created BFD Session for: %x-%x on %s:%s", dstISDs[i], dstASes[i], self.dstIPs[i], self.dstUDPPorts[i])
+            
+    # Set a session to a new state
+    def updateState(self, bfdSession, state, rxInterval):
+        bfdSession.setState(state)
+        txInterval = bfdSession.getTxInterval()
+        if txInterval != rxInterval:
+            bfdSession.setTxInterval(rxInterval)
+
+    # Used as a callback if a BFD packet is received
+    def receivedPacket(self, pkt):
+        if SCION in pkt:
+            if pkt[SCION].nextHdr == 0xCB:
+                # Set ingress interface
+                mac = binascii.unhexlify(str(pkt[Ether].src).replace(':', ''))
+                for i in range(len(self.egressPorts)):
+                    if self.egressPorts[i] == int.from_bytes(mac, byteorder='big'):
+                        ingress = self.egressInterfaces[i]
+                # Perform checks to verify received BFD packet is valid
+                if pkt[BFD].version != 1:
+                    return
+                if pkt[BFD].flags.A == 0 and pkt[BFD].len < 24:
+                    return
+                if pkt[BFD].flags.A == 1 and pkt[BFD].len < 26:
+                    return
+                if pkt[BFD].len > pkt[SCION].payloadLen:
+                    return
+                if pkt[BFD].detect_mult == 0:
+                    return
+                if pkt[BFD].flags.M != 0:
+                    return
+                if pkt[BFD].my_discriminator == 0:
+                    return
+                if pkt[BFD].your_discriminator == 0 and (pkt[BFD].sta == BFD_UP or pkt[BFD].sta == BFD_INIT):
+                    return
+                # TODO: Authentication is not supported by this code so far... Can be implemented
+                if pkt[BFD].flags.A == 1:
+                    return
+                logger.debug("Received valid BFD Packet from %x-%x on %s:%s", pkt[SCION].srcISD, pkt[SCION].srcAS, socket.inet_ntoa(pkt[SCION].srcAddress), pkt[UDP].sport)
+                # Match the packet to a BFD session
+                for i in range(len(self.egressInterfaces)):
+                    if self.egressInterfaces[i] == ingress and ((pkt[SCION].srcAS != self.hostAS or pkt[SCION].srcISD != self.hostISD) or
+                        (pkt[SCION].srcAS == self.hostAS and pkt[SCION].srcISD == self.hostISD and 
+                         pkt[UDP].sport == self.dstUDPPorts[i] and socket.inet_ntoa(pkt[SCION].srcAddress) == self.dstIPs[i])):
+
+                        # Get matching BFD session
+                        bfdSession = self.bfdSessions[i]
+                        logger.debug("Found BFD Session: %s", bfdSession)
+
+                        # Set received discriminator - function checks, whether it is valid and
+                        # only performs set, if the value has changed
+                        if (self.bfdSessions[i].setYourDiscrimi(pkt[BFD].my_discriminator) >= 0):
+                            state = bfdSession.getState()
+                            # Implementation of the BFD state machine
+                            if pkt[BFD].sta == BFD_DOWN:
+                                if state == BFD_DOWN:
+                                    self.updateState(bfdSession, BFD_INIT, pkt[BFD].min_rx_interval)
+                                if state == BFD_UP:
+                                    self.updateState(bfdSession, BFD_DOWN, 1000000)
+                            if pkt[BFD].sta == BFD_INIT:
+                                if state != BFD_UP:
+                                    self.updateState(bfdSession, BFD_UP, pkt[BFD].min_rx_interval)
+                            if pkt[BFD].sta == BFD_UP:
+                                if state == BFD_INIT:
+                                    self.updateState(bfdSession, BFD_UP, pkt[BFD].min_rx_interval)
+
+                        # Reset timeout for the session using the longer interval (either the own interval or the peer's interval)
+                        minTxInterval = bfdSession.getTxInterval()
+                        if minTxInterval < pkt[BFD].min_tx_interval:
+                            minTxInterval = pkt[BFD].min_tx_interval
+                                
+                        bfdSession.setLastRxTime(pkt[BFD].detect_mult * minTxInterval / 1000000)
+                        return
+
+    # Run BFD session handler
+    def run(self):
+        # Start each session in an own process
+        for session in self.bfdSessions:
+            newProcess = Process(target=session.run)
+            # Use deamon to stop process automatically when class is destroyed
+            newProcess.daemon = True
+            newProcess.start()
+            # Safe all session processes
+            self.bfdProcesses.append(newProcess)
+
+bind_layers(Ether, Ether, type = 0x5C10)
+

--- a/controller/scion_grpc/hopfields_pb2.py
+++ b/controller/scion_grpc/hopfields_pb2.py
@@ -3,6 +3,7 @@
 # source: scion_grpc/hopfields.proto
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -13,207 +14,15 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor.FileDescriptor(
-  name='scion_grpc/hopfields.proto',
-  package='proto.control_plane.v1',
-  syntax='proto3',
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x1ascion_grpc/hopfields.proto\x12\x16proto.control_plane.v1\"\xb5\x01\n\x1cHopFieldsRegistrationRequest\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x12\n\nsegment_id\x18\x02 \x01(\r\x12\x33\n\thop_field\x18\x03 \x01(\x0b\x32 .proto.control_plane.v1.HopField\x12\x39\n\x0fpeer_hop_fields\x18\x04 \x03(\x0b\x32 .proto.control_plane.v1.HopField\"J\n\x08HopField\x12\x0f\n\x07ingress\x18\x01 \x01(\x04\x12\x0e\n\x06\x65gress\x18\x02 \x01(\x04\x12\x10\n\x08\x65xp_time\x18\x03 \x01(\r\x12\x0b\n\x03mac\x18\x04 \x01(\x0c\"\x1f\n\x1dHopFieldsRegistrationResponse\"\x1f\n\x1dRemoveExpiredHopFieldsRequest\" \n\x1eRemoveExpiredHopFieldsResponse2\xb3\x02\n\x1cHopFieldsRegistrationService\x12\x86\x01\n\x15HopFieldsRegistration\x12\x34.proto.control_plane.v1.HopFieldsRegistrationRequest\x1a\x35.proto.control_plane.v1.HopFieldsRegistrationResponse\"\x00\x12\x89\x01\n\x16RemoveExpiredHopFields\x12\x35.proto.control_plane.v1.RemoveExpiredHopFieldsRequest\x1a\x36.proto.control_plane.v1.RemoveExpiredHopFieldsResponse\"\x00\x62\x06proto3'
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1ascion_grpc/hopfields.proto\x12\x16proto.control_plane.v1\"\xb5\x01\n\x1cHopFieldsRegistrationRequest\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x12\n\nsegment_id\x18\x02 \x01(\r\x12\x33\n\thop_field\x18\x03 \x01(\x0b\x32 .proto.control_plane.v1.HopField\x12\x39\n\x0fpeer_hop_fields\x18\x04 \x03(\x0b\x32 .proto.control_plane.v1.HopField\"J\n\x08HopField\x12\x0f\n\x07ingress\x18\x01 \x01(\x04\x12\x0e\n\x06\x65gress\x18\x02 \x01(\x04\x12\x10\n\x08\x65xp_time\x18\x03 \x01(\r\x12\x0b\n\x03mac\x18\x04 \x01(\x0c\"\x1f\n\x1dHopFieldsRegistrationResponse\"\x1f\n\x1dRemoveExpiredHopFieldsRequest\" \n\x1eRemoveExpiredHopFieldsResponse2\xb3\x02\n\x1cHopFieldsRegistrationService\x12\x86\x01\n\x15HopFieldsRegistration\x12\x34.proto.control_plane.v1.HopFieldsRegistrationRequest\x1a\x35.proto.control_plane.v1.HopFieldsRegistrationResponse\"\x00\x12\x89\x01\n\x16RemoveExpiredHopFields\x12\x35.proto.control_plane.v1.RemoveExpiredHopFieldsRequest\x1a\x36.proto.control_plane.v1.RemoveExpiredHopFieldsResponse\"\x00\x62\x06proto3')
 
 
 
-
-_HOPFIELDSREGISTRATIONREQUEST = _descriptor.Descriptor(
-  name='HopFieldsRegistrationRequest',
-  full_name='proto.control_plane.v1.HopFieldsRegistrationRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='timestamp', full_name='proto.control_plane.v1.HopFieldsRegistrationRequest.timestamp', index=0,
-      number=1, type=3, cpp_type=2, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='segment_id', full_name='proto.control_plane.v1.HopFieldsRegistrationRequest.segment_id', index=1,
-      number=2, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='hop_field', full_name='proto.control_plane.v1.HopFieldsRegistrationRequest.hop_field', index=2,
-      number=3, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='peer_hop_fields', full_name='proto.control_plane.v1.HopFieldsRegistrationRequest.peer_hop_fields', index=3,
-      number=4, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=55,
-  serialized_end=236,
-)
-
-
-_HOPFIELD = _descriptor.Descriptor(
-  name='HopField',
-  full_name='proto.control_plane.v1.HopField',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='ingress', full_name='proto.control_plane.v1.HopField.ingress', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='egress', full_name='proto.control_plane.v1.HopField.egress', index=1,
-      number=2, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='exp_time', full_name='proto.control_plane.v1.HopField.exp_time', index=2,
-      number=3, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='mac', full_name='proto.control_plane.v1.HopField.mac', index=3,
-      number=4, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=238,
-  serialized_end=312,
-)
-
-
-_HOPFIELDSREGISTRATIONRESPONSE = _descriptor.Descriptor(
-  name='HopFieldsRegistrationResponse',
-  full_name='proto.control_plane.v1.HopFieldsRegistrationResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=314,
-  serialized_end=345,
-)
-
-
-_REMOVEEXPIREDHOPFIELDSREQUEST = _descriptor.Descriptor(
-  name='RemoveExpiredHopFieldsRequest',
-  full_name='proto.control_plane.v1.RemoveExpiredHopFieldsRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=347,
-  serialized_end=378,
-)
-
-
-_REMOVEEXPIREDHOPFIELDSRESPONSE = _descriptor.Descriptor(
-  name='RemoveExpiredHopFieldsResponse',
-  full_name='proto.control_plane.v1.RemoveExpiredHopFieldsResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=380,
-  serialized_end=412,
-)
-
-_HOPFIELDSREGISTRATIONREQUEST.fields_by_name['hop_field'].message_type = _HOPFIELD
-_HOPFIELDSREGISTRATIONREQUEST.fields_by_name['peer_hop_fields'].message_type = _HOPFIELD
-DESCRIPTOR.message_types_by_name['HopFieldsRegistrationRequest'] = _HOPFIELDSREGISTRATIONREQUEST
-DESCRIPTOR.message_types_by_name['HopField'] = _HOPFIELD
-DESCRIPTOR.message_types_by_name['HopFieldsRegistrationResponse'] = _HOPFIELDSREGISTRATIONRESPONSE
-DESCRIPTOR.message_types_by_name['RemoveExpiredHopFieldsRequest'] = _REMOVEEXPIREDHOPFIELDSREQUEST
-DESCRIPTOR.message_types_by_name['RemoveExpiredHopFieldsResponse'] = _REMOVEEXPIREDHOPFIELDSRESPONSE
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
+_HOPFIELDSREGISTRATIONREQUEST = DESCRIPTOR.message_types_by_name['HopFieldsRegistrationRequest']
+_HOPFIELD = DESCRIPTOR.message_types_by_name['HopField']
+_HOPFIELDSREGISTRATIONRESPONSE = DESCRIPTOR.message_types_by_name['HopFieldsRegistrationResponse']
+_REMOVEEXPIREDHOPFIELDSREQUEST = DESCRIPTOR.message_types_by_name['RemoveExpiredHopFieldsRequest']
+_REMOVEEXPIREDHOPFIELDSRESPONSE = DESCRIPTOR.message_types_by_name['RemoveExpiredHopFieldsResponse']
 HopFieldsRegistrationRequest = _reflection.GeneratedProtocolMessageType('HopFieldsRegistrationRequest', (_message.Message,), {
   'DESCRIPTOR' : _HOPFIELDSREGISTRATIONREQUEST,
   '__module__' : 'scion_grpc.hopfields_pb2'
@@ -249,41 +58,20 @@ RemoveExpiredHopFieldsResponse = _reflection.GeneratedProtocolMessageType('Remov
   })
 _sym_db.RegisterMessage(RemoveExpiredHopFieldsResponse)
 
+_HOPFIELDSREGISTRATIONSERVICE = DESCRIPTOR.services_by_name['HopFieldsRegistrationService']
+if _descriptor._USE_C_DESCRIPTORS == False:
 
-
-_HOPFIELDSREGISTRATIONSERVICE = _descriptor.ServiceDescriptor(
-  name='HopFieldsRegistrationService',
-  full_name='proto.control_plane.v1.HopFieldsRegistrationService',
-  file=DESCRIPTOR,
-  index=0,
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_start=415,
-  serialized_end=722,
-  methods=[
-  _descriptor.MethodDescriptor(
-    name='HopFieldsRegistration',
-    full_name='proto.control_plane.v1.HopFieldsRegistrationService.HopFieldsRegistration',
-    index=0,
-    containing_service=None,
-    input_type=_HOPFIELDSREGISTRATIONREQUEST,
-    output_type=_HOPFIELDSREGISTRATIONRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='RemoveExpiredHopFields',
-    full_name='proto.control_plane.v1.HopFieldsRegistrationService.RemoveExpiredHopFields',
-    index=1,
-    containing_service=None,
-    input_type=_REMOVEEXPIREDHOPFIELDSREQUEST,
-    output_type=_REMOVEEXPIREDHOPFIELDSRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-])
-_sym_db.RegisterServiceDescriptor(_HOPFIELDSREGISTRATIONSERVICE)
-
-DESCRIPTOR.services_by_name['HopFieldsRegistrationService'] = _HOPFIELDSREGISTRATIONSERVICE
-
+  DESCRIPTOR._options = None
+  _HOPFIELDSREGISTRATIONREQUEST._serialized_start=55
+  _HOPFIELDSREGISTRATIONREQUEST._serialized_end=236
+  _HOPFIELD._serialized_start=238
+  _HOPFIELD._serialized_end=312
+  _HOPFIELDSREGISTRATIONRESPONSE._serialized_start=314
+  _HOPFIELDSREGISTRATIONRESPONSE._serialized_end=345
+  _REMOVEEXPIREDHOPFIELDSREQUEST._serialized_start=347
+  _REMOVEEXPIREDHOPFIELDSREQUEST._serialized_end=378
+  _REMOVEEXPIREDHOPFIELDSRESPONSE._serialized_start=380
+  _REMOVEEXPIREDHOPFIELDSRESPONSE._serialized_end=412
+  _HOPFIELDSREGISTRATIONSERVICE._serialized_start=415
+  _HOPFIELDSREGISTRATIONSERVICE._serialized_end=722
 # @@protoc_insertion_point(module_scope)

--- a/example_setup/README.md
+++ b/example_setup/README.md
@@ -93,7 +93,7 @@ cd $P4_SCION
 python3 controller/load_config.py $CONFIG/switch_config.json
 python3 controller/hopfields_registration_server.py
 python3 controller/remove_expired_hop_fields.py
-sudo python3 controller/onehop_processor.py -k $SCION/gen/ASff00_0_110/keys/master0.key -m $CONFIG/interface_mapping.json
+sudo python3 controller/onehop_processor.py -k $SCION/gen/ASff00_0_110/keys/master0.key -m $CONFIG/interface_mapping.json -b $CONFIG/bfd_config.json
 ```
 
 For the SCION VM we have two different configurations: one where AS 110 is the core AS and AS 111 and AS 112 are children and one where AS 112 is the core AS, AS 110 is a child of AS 112 and AS 111 is a child of AS 110. The configurations for SCION can be found in `config/scion-parent` and `config/scion-child` respectively.

--- a/example_setup/config/bfd_config.json
+++ b/example_setup/config/bfd_config.json
@@ -1,0 +1,15 @@
+{
+  "localISD": 1,
+  "localAS": "ff0000000110",
+  "localDestinations": [],
+  "localInterfaces": [],
+  "remoteDestinations": [
+    { "egressInterface": 1, "egressPortId": 1, "dstIP": "10.0.10.10", "dstMAC": "08:00:27:22:82:4a", "dstPort": 50000, "dstISD": 1, "dstAS": "ff0000000111" },
+    { "egressInterface": 2, "egressPortId": 2, "dstIP": "10.0.20.10", "dstMAC": "08:00:27:3e:ac:95", "dstPort": 50000, "dstISD": 1, "dstAS": "ff0000000112" }
+  ],
+  "localSource": [
+    { "egressPortId": 1, "srcIP": "10.0.10.5", "srcMAC": "08:00:27:b4:c9:7a", "srcPort": 50000},
+    { "egressPortId": 2, "srcIP": "10.0.20.5", "srcMAC": "08:00:27:1d:8e:1a", "srcPort": 50000},
+    { "egressPortId": 3, "srcIP": "10.0.30.5", "srcMAC": "08:00:27:2c:f8:c4", "srcPort": 50000}
+  ]
+}

--- a/p4src/headers/scion.p4
+++ b/p4src/headers/scion.p4
@@ -32,6 +32,7 @@ typedef bit<16> isdAddr_t;
 typedef bit<48> asAddr_t;
 
 enum bit<8> PathType {
+  EMPTY = 0x00,
   SCION = 0x01,
   ONEHOP = 0x02
 }
@@ -98,11 +99,10 @@ header scion_info_field_t {
 }
 
 header scion_hop_field_t {
-    bit<6>    rsv;
-    bit<1>    ingressRouterAlert;
-    bit<1>    egressRouterAlert;
+    bit<8>    routerAlerts;
     bit<8>    expTime;
     bit<16>   inIf;
     bit<16>   egIf;
     bit<48>   mac;
 }
+

--- a/scion-patch/README.md
+++ b/scion-patch/README.md
@@ -2,7 +2,7 @@ This patch add functionality to SCION to register hop fields when they are gener
 
 Start by cloning the SCION source code from https://github.com/scionproto/scion
 
-This patch was generated against commit `cc33b6ecc62448b2c3a2484bde56844a57048b58`.
+This patch was generated against commit `2ade82199e4bfceea98b2b4594171df58633b4c0`.
 
 Apply the patch using git in the SCION source directory:
 `git apply scion.patch`

--- a/scion-patch/scion.patch
+++ b/scion-patch/scion.patch
@@ -1,7 +1,29 @@
-diff --git a/go/cs/beaconing/extender.go b/go/cs/beaconing/extender.go
-index ff026164..7157c760 100644
---- a/go/cs/beaconing/extender.go
-+++ b/go/cs/beaconing/extender.go
+From 0508b70f88c71f1f309bedd3db4ed3e3c9dc2684 Mon Sep 17 00:00:00 2001
+From: LencigGaer <unwi567@o2online.de>
+Date: Thu, 25 Aug 2022 16:08:02 +0200
+Subject: [PATCH] Added hop field registration server
+
+---
+ control/beaconing/extender.go              |  49 +++
+ control/beaconing/grpc/BUILD.bazel         |   1 +
+ control/beaconing/grpc/hopfields_sender.go |  46 +++
+ control/cmd/control/main.go                |  12 +
+ control/onehop/BUILD.bazel                 |   2 +
+ control/tasks.go                           |  20 +-
+ pkg/proto/control_plane/hopfields.pb.go    | 344 +++++++++++++++++++++
+ pkg/segment/hop.go                         |  13 +
+ private/env/env.go                         |   3 +
+ proto/control_plane/v1/BUILD.bazel         |   1 +
+ proto/control_plane/v1/hopfields.proto     |  27 ++
+ 11 files changed, 509 insertions(+), 9 deletions(-)
+ create mode 100644 control/beaconing/grpc/hopfields_sender.go
+ create mode 100644 pkg/proto/control_plane/hopfields.pb.go
+ create mode 100644 proto/control_plane/v1/hopfields.proto
+
+diff --git a/control/beaconing/extender.go b/control/beaconing/extender.go
+index 2c02c5e35..b760ce90f 100644
+--- a/control/beaconing/extender.go
++++ b/control/beaconing/extender.go
 @@ -18,6 +18,7 @@ import (
  	"context"
  	"encoding/binary"
@@ -9,12 +31,12 @@ index ff026164..7157c760 100644
 +	"net"
  	"time"
  
- 	"github.com/scionproto/scion/go/cs/ifstate"
-@@ -65,6 +66,45 @@ type DefaultExtender struct {
+ 	"github.com/scionproto/scion/control/ifstate"
+@@ -60,6 +61,45 @@ type DefaultExtender struct {
  	StaticInfo func() *StaticInfoCfg
  	// EPIC defines whether the EPIC authenticators should be added when the segment is extended.
  	EPIC bool
-+	HopFieldsSender HopFieldsSender
++    HopFieldsSender HopFieldsSender
 +}
 +
 +type RPCHopFields interface {
@@ -56,7 +78,7 @@ index ff026164..7157c760 100644
  }
  
  // Extend extends the beacon with hop fields of the old format.
-@@ -106,6 +146,15 @@ func (s *DefaultExtender) Extend(ctx context.Context, pseg *seg.PathSegment,
+@@ -105,6 +145,15 @@ func (s *DefaultExtender) Extend(
  		PeerEntries: peerEntries,
  		MTU:         int(s.MTU),
  	}
@@ -72,10 +94,10 @@ index ff026164..7157c760 100644
  	if static := s.StaticInfo(); static != nil {
  		asEntry.Extensions.StaticInfo = static.Generate(s.Intfs, ingress, egress)
  	}
-diff --git a/go/cs/beaconing/grpc/BUILD.bazel b/go/cs/beaconing/grpc/BUILD.bazel
-index 8bd9cd56..e28b7cf6 100644
---- a/go/cs/beaconing/grpc/BUILD.bazel
-+++ b/go/cs/beaconing/grpc/BUILD.bazel
+diff --git a/control/beaconing/grpc/BUILD.bazel b/control/beaconing/grpc/BUILD.bazel
+index ef8773add..1960af570 100644
+--- a/control/beaconing/grpc/BUILD.bazel
++++ b/control/beaconing/grpc/BUILD.bazel
 @@ -5,6 +5,7 @@ go_library(
      srcs = [
          "beacon_sender.go",
@@ -83,12 +105,12 @@ index 8bd9cd56..e28b7cf6 100644
 +        "hopfields_sender.go",
          "register.go",
      ],
-     importpath = "github.com/scionproto/scion/go/cs/beaconing/grpc",
-diff --git a/go/cs/beaconing/grpc/hopfields_sender.go b/go/cs/beaconing/grpc/hopfields_sender.go
+     importpath = "github.com/scionproto/scion/control/beaconing/grpc",
+diff --git a/control/beaconing/grpc/hopfields_sender.go b/control/beaconing/grpc/hopfields_sender.go
 new file mode 100644
-index 00000000..2ad75fd8
+index 000000000..5b03d47f1
 --- /dev/null
-+++ b/go/cs/beaconing/grpc/hopfields_sender.go
++++ b/control/beaconing/grpc/hopfields_sender.go
 @@ -0,0 +1,46 @@
 +package grpc
 +
@@ -97,9 +119,9 @@ index 00000000..2ad75fd8
 +	"net"
 +	"time"
 +
-+	"github.com/scionproto/scion/go/lib/ctrl/seg"
-+	"github.com/scionproto/scion/go/pkg/grpc"
-+	cppb "github.com/scionproto/scion/go/pkg/proto/control_plane"
++	"github.com/scionproto/scion/pkg/segment"
++	"github.com/scionproto/scion/pkg/grpc"
++	cppb "github.com/scionproto/scion/pkg/proto/control_plane"
 +)
 +
 +// HopFieldsSender propagates beacons.
@@ -110,10 +132,10 @@ index 00000000..2ad75fd8
 +
 +// SendHopFields sends a beacon to the remote.
 +func (r HopFieldsSender) SendHopFields(ctx context.Context, timestamp time.Time, segID uint16,
-+	hopField seg.HopField, peerEntries []seg.PeerEntry, remote net.Addr) error {
++	hopField segment.HopField, peerEntries []segment.PeerEntry, remote net.Addr) error {
 +	peerHopFields := []*cppb.HopField{}
 +	for _, p := range peerEntries {
-+		peerHopFields = append(peerHopFields, seg.HopFieldToPB(&p.HopField))
++		peerHopFields = append(peerHopFields, segment.HopFieldToPB(&p.HopField))
 +	}
 +
 +	// TODO include beta for peer entries
@@ -129,29 +151,30 @@ index 00000000..2ad75fd8
 +		&cppb.HopFieldsRegistrationRequest{
 +			Timestamp:     timestamp.Unix(),
 +			SegmentId:     uint32(segID),
-+			HopField:      seg.HopFieldToPB(&hopField),
++			HopField:      segment.HopFieldToPB(&hopField),
 +			PeerHopFields: peerHopFields,
 +		},
 +		grpc.RetryProfile...,
 +	)
 +	return err
 +}
-diff --git a/go/cs/main.go b/go/cs/main.go
-index ca0f1cce..dc29b9af 100644
---- a/go/cs/main.go
-+++ b/go/cs/main.go
-@@ -141,6 +141,7 @@ func realMain() error {
- 		Rewriter: nc.AddressRewriter(nil),
- 		Dialer:   quicStack.Dialer,
+diff --git a/control/cmd/control/main.go b/control/cmd/control/main.go
+index b5db65df9..15d46533a 100644
+--- a/control/cmd/control/main.go
++++ b/control/cmd/control/main.go
+@@ -189,6 +189,7 @@ func realMain(ctx context.Context) error {
+ 		},
+ 		Dialer: quicStack.Dialer,
  	}
 +	simpleDialer := &libgrpc.SimpleDialer{}
  
  	trustDB, err := storage.NewTrustStorage(globalCfg.TrustDB)
  	if err != nil {
-@@ -549,6 +550,16 @@ func realMain() error {
- 			},
- 		},
- 	)
+@@ -652,6 +653,16 @@ func realMain(ctx context.Context) error {
+ 		topoInfo := intf.TopoInfo()
+ 		return topoInfo.LinkType == topology.Core || topoInfo.LinkType == topology.Child
+ 	}
++	
 +	log.Debug("globalCfg.General.HopFieldsRegistrationServer",
 +		"globalCfg.General.HopFieldsRegistrationServer",
 +		globalCfg.General.HopFieldsRegistrationServer)
@@ -161,173 +184,74 @@ index ca0f1cce..dc29b9af 100644
 +			Dialer: simpleDialer,
 +		},
 +	}
-+
+ 
  	tasks, err := cs.StartTasks(cs.TasksConfig{
- 		Public:   nc.Public,
- 		Intfs:    intfs,
-@@ -566,7 +577,9 @@ func realMain() error {
- 			RPC: beaconinggrpc.BeaconSender{
- 				Dialer: dialer,
- 			},
-+			HopFieldsSender: hopFieldsSender,
+ 		IA:            topo.IA(),
+@@ -671,6 +682,7 @@ func realMain(ctx context.Context) error {
+ 		BeaconSenderFactory: &beaconinggrpc.BeaconSenderFactory{
+ 			Dialer: dialer,
  		},
 +		HopFieldsSender: hopFieldsSender,
  		SegmentRegister: beaconinggrpc.Registrar{Dialer: dialer},
  		BeaconStore:     beaconStore,
  		Signer:          signer,
-diff --git a/go/cs/onehop/BUILD.bazel b/go/cs/onehop/BUILD.bazel
-index 7c797ff4..4c27ea04 100644
---- a/go/cs/onehop/BUILD.bazel
-+++ b/go/cs/onehop/BUILD.bazel
-@@ -9,12 +9,14 @@ go_library(
-     importpath = "github.com/scionproto/scion/go/cs/onehop",
+diff --git a/control/onehop/BUILD.bazel b/control/onehop/BUILD.bazel
+index 0cd018e8a..4c51d1d1e 100644
+--- a/control/onehop/BUILD.bazel
++++ b/control/onehop/BUILD.bazel
+@@ -6,7 +6,9 @@ go_library(
+     importpath = "github.com/scionproto/scion/control/onehop",
      visibility = ["//visibility:public"],
      deps = [
-+        "//go/cs/beaconing:go_default_library",
-         "//go/lib/addr:go_default_library",
-         "//go/lib/common:go_default_library",
-         "//go/lib/ctrl/seg:go_default_library",
-         "//go/lib/infra/messenger:go_default_library",
-         "//go/lib/log:go_default_library",
-         "//go/lib/serrors:go_default_library",
-+        "//go/lib/slayers/path/onehop:go_default_library",
-         "//go/lib/snet:go_default_library",
-         "//go/lib/spath:go_default_library",
-     ],
-diff --git a/go/cs/onehop/sender.go b/go/cs/onehop/sender.go
-index ce4cf43a..bc4b7375 100644
---- a/go/cs/onehop/sender.go
-+++ b/go/cs/onehop/sender.go
-@@ -22,12 +22,14 @@ import (
- 	"sync"
- 	"time"
- 
-+	"github.com/scionproto/scion/go/cs/beaconing"
- 	"github.com/scionproto/scion/go/lib/addr"
- 	"github.com/scionproto/scion/go/lib/common"
- 	"github.com/scionproto/scion/go/lib/ctrl/seg"
- 	"github.com/scionproto/scion/go/lib/infra/messenger"
- 	"github.com/scionproto/scion/go/lib/log"
- 	"github.com/scionproto/scion/go/lib/serrors"
-+	"github.com/scionproto/scion/go/lib/slayers/path/onehop"
- 	"github.com/scionproto/scion/go/lib/snet"
- 	"github.com/scionproto/scion/go/lib/spath"
- )
-@@ -117,6 +119,15 @@ type BeaconSender struct {
- 	// resolution is not attempted.
- 	AddressRewriter *messenger.AddressRewriter
- 	RPC             RPC
-+	HopFieldsSender beaconing.HopFieldsSender
-+}
-+
-+func (s *BeaconSender) registerHopFields(ctx context.Context, timestamp time.Time, segID uint16,
-+	hopField seg.HopField, peerEntries []seg.PeerEntry) error {
-+	log.Debug("register hop fields at hop fields registration server", "timestamp", timestamp,
-+		"segID", segID, "hopField", hopField, "peerEntries", peerEntries)
-+	s.HopFieldsSender.Send(ctx, timestamp, segID, hopField, peerEntries)
-+	return nil
- }
- 
- // Send packs and sends out the beacon.
-@@ -128,6 +139,20 @@ func (s *BeaconSender) Send(ctx context.Context, bseg *seg.PathSegment, ia addr.
- 		return err
- 	}
- 
-+	log.Debug("Created OneHop path", "path", (spath.Path)(path))
-+	var ohp onehop.Path
-+	if err := ohp.DecodeFromBytes(path.Raw); err != nil {
-+		return serrors.WrapStr("decoding v2 OHP path", err)
-+	}
-+	log.Debug("Decoded path", "path", ohp)
-+	s.registerHopFields(ctx, time.Unix((int64)(ohp.Info.Timestamp), 0), ohp.Info.SegID,
-+		seg.HopField{
-+			ExpTime:     ohp.FirstHop.ExpTime,
-+			ConsIngress: ohp.FirstHop.ConsIngress,
-+			ConsEgress:  ohp.FirstHop.ConsEgress,
-+			MAC:         ohp.FirstHop.Mac},
-+		[]seg.PeerEntry{})
-+
- 	svc := &snet.SVCAddr{
- 		IA:      ia,
- 		Path:    (spath.Path)(path),
-diff --git a/go/lib/ctrl/seg/hop.go b/go/lib/ctrl/seg/hop.go
-index f9fb8b81..fd6f3528 100644
---- a/go/lib/ctrl/seg/hop.go
-+++ b/go/lib/ctrl/seg/hop.go
-@@ -119,3 +119,16 @@ func hopFieldFromPB(pb *cppb.HopField) (HopField, error) {
- 		MAC:         pb.Mac,
- 	}, nil
- }
-+
-+func HopFieldToPB(hf *HopField) *cppb.HopField {
-+	if hf == nil {
-+		panic("hop field must not be nil")
-+	}
-+
-+	return &cppb.HopField{
-+		Ingress: uint64(hf.ConsIngress),
-+		Egress:  uint64(hf.ConsEgress),
-+		ExpTime: uint32(hf.ExpTime),
-+		Mac:     hf.MAC,
-+	}
-+}
-diff --git a/go/lib/env/env.go b/go/lib/env/env.go
-index db9d3590..b80b1c5d 100644
---- a/go/lib/env/env.go
-+++ b/go/lib/env/env.go
-@@ -81,6 +81,9 @@ type General struct {
- 	// ReconnectToDispatcher can be set to true to enable transparent dispatcher
- 	// reconnects.
- 	ReconnectToDispatcher bool `toml:"reconnect_to_dispatcher,omitempty"`
-+	// HopFieldsRegistrationServer is the address of the server to register the generated hop field
-+	// for devices that cannot perform the required crypto themselves
-+	HopFieldsRegistrationServer string `toml:"hop_fields_registration_server,omitempty"`
- }
- 
- // InitDefaults sets the default value for Topology if not already set.
-diff --git a/go/pkg/cs/tasks.go b/go/pkg/cs/tasks.go
-index 1c2588a9..e6861dfa 100644
---- a/go/pkg/cs/tasks.go
-+++ b/go/pkg/cs/tasks.go
-@@ -51,6 +51,7 @@ type TasksConfig struct {
- 	RevCache        revcache.RevCache
- 	BeaconSender    beaconing.BeaconSender
- 	SegmentRegister beaconing.RPC
-+	HopFieldsSender beaconing.HopFieldsSender
- 	BeaconStore     Store
- 	Signer          seg.Signer
- 	Inspector       trust.Inspector
-@@ -202,15 +203,16 @@ func (t *TasksConfig) extender(task string, ia addr.IA, mtu uint16,
++        "//control/beaconing:go_default_library",
+         "//pkg/addr:go_default_library",
++        "//pkg/slayers/path/onehop:go_default_library",
+         "//pkg/snet:go_default_library",
+         "//pkg/snet/path:go_default_library",
+         "//private/app/appnet:go_default_library",
+diff --git a/control/tasks.go b/control/tasks.go
+index 9fb8de43a..96e7bd10a 100644
+--- a/control/tasks.go
++++ b/control/tasks.go
+@@ -53,6 +53,7 @@ type TasksConfig struct {
+ 	PathDB                pathdb.DB
+ 	RevCache              revcache.RevCache
+ 	BeaconSenderFactory   beaconing.SenderFactory
++	HopFieldsSender       beaconing.HopFieldsSender
+ 	SegmentRegister       beaconing.RPC
+ 	BeaconStore           Store
+ 	Signer                seg.Signer
+@@ -200,15 +201,16 @@ func (t *TasksConfig) extender(task string, ia addr.IA, mtu uint16,
  	maxExp func() uint8) beaconing.Extender {
  
  	return &beaconing.DefaultExtender{
 -		IA:         ia,
 -		Signer:     t.Signer,
 -		MAC:        t.MACGen,
--		Intfs:      t.Intfs,
+-		Intfs:      t.AllInterfaces,
 -		MTU:        mtu,
--		MaxExpTime: func() uint8 { return uint8(maxExp()) },
+-		MaxExpTime: func() uint8 { return maxExp() },
 -		StaticInfo: t.StaticInfo,
 -		Task:       task,
--		EPIC:       false,
+-		EPIC:       t.EPIC,
 +		IA:              ia,
 +		Signer:          t.Signer,
 +		MAC:             t.MACGen,
-+		Intfs:           t.Intfs,
++		Intfs:           t.AllInterfaces,
 +		MTU:             mtu,
-+		MaxExpTime:      func() uint8 { return uint8(maxExp()) },
++		MaxExpTime:      func() uint8 { return maxExp() },
 +		StaticInfo:      t.StaticInfo,
 +		Task:            task,
-+		EPIC:            false,
++		EPIC:            t.EPIC,
 +		HopFieldsSender: t.HopFieldsSender,
  	}
  }
  
-diff --git a/go/pkg/proto/control_plane/hopfields.pb.go b/go/pkg/proto/control_plane/hopfields.pb.go
+diff --git a/pkg/proto/control_plane/hopfields.pb.go b/pkg/proto/control_plane/hopfields.pb.go
 new file mode 100644
-index 00000000..e18805a8
+index 000000000..c14674d98
 --- /dev/null
-+++ b/go/pkg/proto/control_plane/hopfields.pb.go
++++ b/pkg/proto/control_plane/hopfields.pb.go
 @@ -0,0 +1,344 @@
 +// Code generated by protoc-gen-go. DO NOT EDIT.
 +// versions:
@@ -546,7 +470,7 @@ index 00000000..e18805a8
 +func file_proto_control_plane_v1_hopfields_proto_init() {
 +	if File_proto_control_plane_v1_hopfields_proto != nil {
 +		return
-+	}
++}
 +	file_proto_control_plane_v1_seg_proto_init()
 +	if !protoimpl.UnsafeEnabled {
 +		file_proto_control_plane_v1_hopfields_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
@@ -574,10 +498,10 @@ index 00000000..e18805a8
 +			}
 +		}
 +	}
-+	type x struct{}
++type x struct{}
 +	out := protoimpl.TypeBuilder{
 +		File: protoimpl.DescBuilder{
-+			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
++		GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 +			RawDescriptor: file_proto_control_plane_v1_hopfields_proto_rawDesc,
 +			NumEnums:      0,
 +			NumMessages:   2,
@@ -627,7 +551,7 @@ index 00000000..e18805a8
 +}
 +
 +// HopFieldsRegistrationServiceServer is the server API for HopFieldsRegistrationService service.
-+type HopFieldsRegistrationServiceServer interface {
++ype HopFieldsRegistrationServiceServer interface {
 +	HopFieldsRegistration(context.Context, *HopFieldsRegistrationRequest) (*HopFieldsRegistrationResponse, error)
 +}
 +
@@ -673,21 +597,43 @@ index 00000000..e18805a8
 +	Streams:  []grpc.StreamDesc{},
 +	Metadata: "proto/control_plane/v1/hopfields.proto",
 +}
-diff --git a/go/pkg/router/control/bfd.go b/go/pkg/router/control/bfd.go
-index 616fc76c..73864343 100644
---- a/go/pkg/router/control/bfd.go
-+++ b/go/pkg/router/control/bfd.go
-@@ -58,7 +58,7 @@ var (
- 		DesiredMinTxInterval:  200 * time.Millisecond,
- 		RequiredMinRxInterval: 200 * time.Millisecond,
- 		// Disable indicates if BFD is disabled globally.
--		Disable: false,
-+		Disable: true,
- 	}
- )
+diff --git a/pkg/segment/hop.go b/pkg/segment/hop.go
+index da2423e51..d90d81b51 100644
+--- a/pkg/segment/hop.go
++++ b/pkg/segment/hop.go
+@@ -122,3 +122,16 @@ func hopFieldFromPB(pb *cppb.HopField) (HopField, error) {
+ 		MAC:         m,
+ 	}, nil
+ }
++
++func HopFieldToPB(hf *HopField) *cppb.HopField {
++	if hf == nil {
++		panic("hop field must not be nil")
++	}
++
++	return &cppb.HopField{
++		Ingress: uint64(hf.ConsIngress),
++		Egress:  uint64(hf.ConsEgress),
++		ExpTime: uint32(hf.ExpTime),
++		Mac:     hf.MAC[:],
++	}
++}
+diff --git a/private/env/env.go b/private/env/env.go
+index 1c59a1822..a03eba8cb 100644
+--- a/private/env/env.go
++++ b/private/env/env.go
+@@ -82,6 +82,9 @@ type General struct {
+ 	// ReconnectToDispatcher can be set to true to enable transparent dispatcher
+ 	// reconnects.
+ 	ReconnectToDispatcher bool `toml:"reconnect_to_dispatcher,omitempty"`
++	// HopFieldsRegistrationServer is the address of the server to register the generated hop field
++	// for devices that cannot perform the required crypto themselves
++	HopFieldsRegistrationServer string `toml:"hop_fields_registration_server,omitempty"`
+ }
  
+ // InitDefaults sets the default value for Topology if not already set.
 diff --git a/proto/control_plane/v1/BUILD.bazel b/proto/control_plane/v1/BUILD.bazel
-index 4ccec841..7c8171b9 100644
+index 7a0e59f88..e40d30f58 100644
 --- a/proto/control_plane/v1/BUILD.bazel
 +++ b/proto/control_plane/v1/BUILD.bazel
 @@ -4,6 +4,7 @@ proto_library(
@@ -695,12 +641,12 @@ index 4ccec841..7c8171b9 100644
      srcs = [
          "cppki.proto",
 +        "hopfields.proto",
-         "legacy.proto",
+         "drkey.proto",
          "renewal.proto",
          "seg.proto",
 diff --git a/proto/control_plane/v1/hopfields.proto b/proto/control_plane/v1/hopfields.proto
 new file mode 100644
-index 00000000..a4d4b302
+index 000000000..a4d4b3020
 --- /dev/null
 +++ b/proto/control_plane/v1/hopfields.proto
 @@ -0,0 +1,27 @@
@@ -731,3 +677,6 @@ index 00000000..a4d4b302
 +}
 +
 +message HopFieldsRegistrationResponse {}
+-- 
+2.25.1
+


### PR DESCRIPTION
# BFD support

This pull request adds BFD protocol support inside the control plane as an extension to the one-hop processor. The BFD support is required to work with SCION versions newer than 0.6.

# Compitablity with newer SDE versions

Furthermore, the p4 code was adapted to compile with current SDE versions (tested for 9.8.0-9.12.0). Unfortunately, the new code does not compile with SDE version 9.5.0 and older.

# List of changed files

To this end, some changes were applied to:
- the scion.patch file to work with SCION commit 2ade82199e4bfceea98b2b4594171df58633b4c0 (SCION version 0.8.0),
- the scion.p4 code to additionally support path type EMPTY which is used by the BFD protocol and
- the one-hop processor to interact with the new BFD script because the one-hop processor is already bound to the Tofino's CPU port.
- The main BFD functionality is realized in an extra file to avoid major changes to your code.
- It needs an additional config file which I also added to the repo.